### PR TITLE
Add a new config option for serial port

### DIFF
--- a/Config/config.json
+++ b/Config/config.json
@@ -37,4 +37,6 @@
 "indoor_mqtt_topic": "<>",
 "city_name": "Sydney",
 "time_zone": "Australia/Sydney",
-"custom_locations": ["Townsville, Australia, Queensland, -19.26639, 146.80569", "Thredbo, Australia, Sydney, -36.4999989, 148.2999988", "Romsey, Australia, Victoria, -37.3581082, 144.7365582"]}
+"custom_locations": ["Townsville, Australia, Queensland, -19.26639, 146.80569", "Thredbo, Australia, Sydney, -36.4999989, 148.2999988", "Romsey, Australia, Victoria, -37.3581082, 144.7365582"],
+"serial_port": "/dev/ttyS0"
+}

--- a/Northcliff_AQI_Monitor_Gen.py
+++ b/Northcliff_AQI_Monitor_Gen.py
@@ -169,6 +169,7 @@ def retrieve_config():
     city_name = parsed_config_parameters['city_name']
     time_zone = parsed_config_parameters['time_zone']
     custom_locations = parsed_config_parameters['custom_locations']
+    serial_port = parsed_config_parameters['serial_port']
     return (temp_offset, altitude, enable_display, enable_adafruit_io, aio_user_name, aio_key, aio_feed_window,
             aio_feed_sequence, aio_household_prefix, aio_location_prefix, aio_package, enable_send_data_to_homemanager,
             enable_receive_data_from_homemanager, enable_indoor_outdoor_functionality,
@@ -177,7 +178,7 @@ def retrieve_config():
             enable_eco2_tvoc, gas_daily_r0_calibration_hour, reset_gas_sensor_calibration, incoming_temp_hum_mqtt_topic,
             incoming_temp_hum_mqtt_sensor_name, incoming_barometer_mqtt_topic, incoming_barometer_sensor_id,
             indoor_outdoor_function, mqtt_client_name, outdoor_mqtt_topic, indoor_mqtt_topic, city_name, time_zone,
-            custom_locations)
+            custom_locations, serial_port)
 
 # Config Setup
 (temp_offset, altitude, enable_display, enable_adafruit_io, aio_user_name, aio_key, aio_feed_window, aio_feed_sequence,
@@ -187,7 +188,7 @@ def retrieve_config():
   enable_luftdaten_noise, disable_luftdaten_sensor_upload, enable_climate_and_gas_logging,  enable_particle_sensor, enable_eco2_tvoc,
   gas_daily_r0_calibration_hour, reset_gas_sensor_calibration, incoming_temp_hum_mqtt_topic, incoming_temp_hum_mqtt_sensor_name,
   incoming_barometer_mqtt_topic, incoming_barometer_sensor_id, indoor_outdoor_function, mqtt_client_name,
-  outdoor_mqtt_topic, indoor_mqtt_topic, city_name, time_zone, custom_locations) = retrieve_config()
+  outdoor_mqtt_topic, indoor_mqtt_topic, city_name, time_zone, custom_locations, serial_port) = retrieve_config()
 
 # Add to city database
 db = database()
@@ -195,7 +196,7 @@ add_locations(custom_locations, db)
 
 if enable_particle_sensor:
     # Create a PMS5003 instance
-    pms5003 = PMS5003()
+    pms5003 = PMS5003(device = serial_port)
     time.sleep(1)
 
 if enable_noise:


### PR DESCRIPTION
I installed this on a Pi Zero 2 W. The code crashed when trying to set up the particulate sensor. I determined this was because the PMS5003 library defaults to `/dev/ttyAMA0` for the serial port. On modern Pis, the serial port is `/dev/ttyS0`. 

This commit adds a config option and set the default to be `/dev/ttyS0`. This fixes this code on my Pi Zero 2 W.